### PR TITLE
Depend on colorway >= 0.2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ BugReports: https://github.com/samuel-marsh/scCustomize/issues
 Depends: Seurat (>= 4.0.6)
 Imports: 
     circlize,
-    colorway,
+    colorway (>= 0.2.0),
     cowplot,
     data.table,
     dittoSeq,

--- a/README.md
+++ b/README.md
@@ -26,10 +26,6 @@ remotes package. For more detailed instructions see
 
     remotes::install_github(repo = "samuel-marsh/scCustomize")
 
-If you had previously installed
-[colorway](https://github.com/hypercompetent/colorway) package prior to
-installing scCustomize please make sure to update to \>= v0.2.0.
-
 **Master branch**  
 Full releases will be available on the master branch with version scheme
 vX.X.X.  


### PR DESCRIPTION
Ensures colorway is up-to-date when installing scCustomize
Prevents scCustomize from loading with old versions of colorway
Removes need for note about old colorway versions