### PR TITLE
ensure `na_ok` is adhered to in `Add_Sample_Meta`

### DIFF
--- a/R/Object_Utilities.R
+++ b/R/Object_Utilities.R
@@ -932,7 +932,7 @@ Add_Sample_Meta <- function(
   }
 
   # Check NA in meta data
-  if (anyNA(x = meta_data)) {
+  if (anyNA(x = meta_data) && !na_ok) {
     cli_abort(message = c("{.code meta_data} contains NA values.",
                           "i" = "If you would like NA values added to Seurat meta data please set {.code na_ok = TRUE}.")
     )


### PR DESCRIPTION
The option `na_ok`  in `Add_Sample_Meta` was ignored because the initial `anyNA` check on line 935 did not take it into account, unlike the later check on line 991. This adds the needed check.