### PR TITLE
Fix naming color palette in SpatialDimPlot_scCustom

### DIFF
--- a/R/Plotting_Seurat.R
+++ b/R/Plotting_Seurat.R
@@ -2759,10 +2759,10 @@ SpatialDimPlot_scCustom <- function(
   if (is.null(x = group.by)) {
     names(colors_use) <- levels(Idents(object = seurat_object))
   } else {
-    if (isTRUE(x = inherits(x = seurat_object[[group.by]], what = "factor"))) {
-      names(colors_use) <- levels(seurat_object[[group.by]])
+    if (isTRUE(x = inherits(x = seurat_object@meta.data[[group.by]], what = "factor"))) {
+      names(colors_use) <- levels(seurat_object@meta.data[[group.by]])
     } else {
-      names(colors_use) <- unique(seurat_object[[group.by]])
+      names(colors_use) <- unique(seurat_object@meta.data[[group.by]])
     }
   }
 


### PR DESCRIPTION
Hi @samuel-marsh , thanks for this great package.

Here is a small PR which fixes a coloring problem that I got:

When I used the function, got this warning message and a plot with all of the clusters colored in grey:
```
Warning messages:
1: No shared levels found between `names(values)` of the manual scale and the data's fill values.
```
Inspecting the source code, I realized that the problem is with how it tries to name the color vector. 
In the Seurat object that I use (v5.3.0) `seurat_object[[group.by]]` yields a data frame, not a vector, leading to the problem.

So, in the “name color palette” section, replaced `seurat_object[[group.by]]` with `seurat_object@meta.data[[group.by]]`.



