### PR TITLE
[codex] Fix figure_plot split panel layout

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 - Fixed default setting of `linewidth` parameter in `geom_hline` and `geom_vline` calls to avoid unnecessary empty aesthetic warnings in ggplot2 4.0.0+.  
 - Fixed warning in `Dataset_Size_LIGER` due to deprecation in `Extract_Sample_Meta`.  
 - Fixed issue with group colors in in `DimPlot_scCustom` when split only contains one group Thanks @zrlewis, ([#262](https://github.com/samuel-marsh/scCustomize/issues/262)).  
+- Fixed `figure_plot = TRUE` dropping split panels in `FeaturePlot_scCustom` when the input plot is already a patchwork. Thanks @wendelljpereira, ([#265](https://github.com/samuel-marsh/scCustomize/issues/265)).
 
   
   

--- a/R/Plotting_Utilities_Internal.R
+++ b/R/Plotting_Utilities_Internal.R
@@ -450,11 +450,22 @@ Overall_Prop_Plot <- function(
 Figure_Plot <- function(
     plot
 ){
-  # pull axis labels
-  x_lab_reduc <- plot$labels$x
-  y_lab_reduc <- plot$labels$y
+  # Pull axis labels from the first panel when figure_plot receives a patchwork.
+  is_composite <- inherits(x = plot, what = "patchwork") && length(x = plot$patches$plots) > 0
+  if (isTRUE(x = is_composite)) {
+    first_panel <- plot$patches$plots[[1]]
+    x_lab_reduc <- first_panel$labels$x %||% plot$labels$x
+    y_lab_reduc <- first_panel$labels$y %||% plot$labels$y
+  } else {
+    x_lab_reduc <- plot$labels$x
+    y_lab_reduc <- plot$labels$y
+  }
 
   plot <- plot & NoAxes()
+
+  if (isTRUE(x = is_composite)) {
+    plot <- wrap_elements(plot)
+  }
 
   axis_plot <- ggplot(data.frame(x= 100, y = 100), aes(x = .data[["x"]], y = .data[["y"]])) +
     geom_point() +


### PR DESCRIPTION
## Summary
- Keep multi-panel patchwork inputs intact in `Figure_Plot()` by wrapping composites before adding the axis legend.
- Pull axis labels from the first panel for composite inputs.
- Add a NEWS entry for the `figure_plot = TRUE` / `split.by` fix.

Fixes #265.

## Validation
- Rendered `FeaturePlot_scCustom(seurat_object = pbmc_small, features = "CD3E", split.by = "groups", num_columns = 2, figure_plot = TRUE)` to PDF and confirmed the patchwork "Too few patch areas..." warning is absent.
- `git diff --check`
